### PR TITLE
fix: modify radiogroup to be in line with vue standards

### DIFF
--- a/src/pages/AccountPage.vue
+++ b/src/pages/AccountPage.vue
@@ -78,8 +78,10 @@
                                         <input
                                             type="radio"
                                             name="radio-group"
-                                            @click="recordSelect"
                                             v-bind:id="payment.pended_on"
+                                            v-bind:value="payment.pended_on"
+                                            v-model="selectedDate"
+                                            @click="onRadioClick(payment.pended_on)"
                                         />
                                     </div>
                                 </div>
@@ -185,7 +187,7 @@
                         <div class="cta-buttons">
                             <button
                                 v-on:click="onRequestSubmissionEmail"
-                                :disabled="selected"
+                                :disabled="!this.selectedDate"
                             >
                                 Email selected payment record
                             </button>
@@ -227,16 +229,15 @@ export default {
             voucherPagination: Store.pendedVoucherPagination,
             errorMessage: Store.error,
             goodFeedback: false,
-            selected: true,
-            selectedDate: null
+            selectedDate: null,
         };
     },
     watch: {},
     methods: {
-        recordSelect: function (event) {
-            this.selected = false;
-            // Default to requesting all.
-            this.selectedDate = event.target.id || null;
+        onRadioClick: function(value) {
+            if (this.selectedDate === value) {
+                this.selectedDate = null;
+            }
         },
         onRequestSubmissionEmail: function () {
             const url =


### PR DESCRIPTION
So, the old "select a payment" radio group button was trying to do a lot manually that vue can do itself.

told it to bind a v-model to the page's selected date - that lets vue handle
- managing which item gets drawn as selected
- the state surviving a situation where then selected item is on another "page" of the pagination

and rewrote the function that handled changes so that the user can click a selection "off", even if that's not a normal thing a radio button does. 

https://trello.com/c/oHXHn5Zj/2182-account-page-payment-selection-issue